### PR TITLE
Fix markdown hyperlink format

### DIFF
--- a/_posts/2019-02-26-ds-lab-2.md
+++ b/_posts/2019-02-26-ds-lab-2.md
@@ -60,8 +60,7 @@ tags: Mff, School, Labs, DS, dialogue systems
     - [All the news](https://www.kaggle.com/snapcrack/all-the-news) - use just the "Article Content"
     - Use at most first 10,000 utterances/sentences if the dataset is large.
     - Describe in 5 sentences the properties of each dataset and explain how they relate to the computed entropy value.
-2. (2 point) Train a Language Model and compute cross entropy on the [Vystadial dataset](- [Vystadial CZ dataset](https://lindat.mff.cuni.cz/repository/xmlui/handle/11858/00-097C-0000-0023-4670-6)
-)
+2. (2 point) Train a Language Model and compute cross entropy on the [Vystadial dataset](https://lindat.mff.cuni.cz/repository/xmlui/handle/11858/00-097C-0000-0023-4670-6)
      - Recommended toolkit - [KenLM](https://github.com/kpu/kenlm)
          - Read the README and train a model `bin/lmplz -o 5 <text >text.arpa` on the Vystadial training set.
          - Compute cross-entropy of the train, dev set and first sentence from dev set. See the [example usage](https://github.com/kpu/kenlm/blob/master/python/example.py)


### PR DESCRIPTION
I fixed an error in the markdown format. Also, is there a reason you link to the 2013 dataset and not the [2016 version](https://lindat.mff.cuni.cz/repository/xmlui/handle/11234/1-1740)?